### PR TITLE
Model summary property and RPT warning function (#154)

### DIFF
--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -179,7 +179,7 @@ class Model(object):
         """
         # first, make sure the rpt is valid
         if self.rpt_is_valid(verbose=verbose):
-            # check if the rpt has ERRORS output from SWMM
+            # check if the rpt has WARNINGS output from SWMM
             warnings = list()
             with open(self.rpt.path) as f:
                 for line in f:
@@ -188,7 +188,9 @@ class Model(object):
                         warnings.append(line[:-1])
                     elif '****************' in line:
                         break
-                return warnings
+        else:
+            warnings = 'RPT file is not valid'
+        return warnings
 
 
     def conduits(self):

--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -136,6 +136,7 @@ class Model(object):
             self._links_df = None
             self._subcatchments_df = None
             self._network = None
+            self._summary = None
 
     def rpt_is_valid(self, verbose=False):
         """
@@ -171,6 +172,24 @@ class Model(object):
             return False
         else:
             return True
+        
+    def rpt_warnings(self, verbose=False):
+        """
+        Return warning messages from the rpt file
+        """
+        # first, make sure the rpt is valid
+        if self.rpt_is_valid(verbose=verbose):
+            # check if the rpt has ERRORS output from SWMM
+            warnings = list()
+            with open(self.rpt.path) as f:
+                for line in f:
+                    spl = line.split()
+                    if len(spl) > 0 and spl[0] == 'WARNING':
+                        warnings.append(line[:-1])
+                    elif '****************' in line:
+                        break
+                return warnings
+
 
     def conduits(self):
         """
@@ -446,6 +465,12 @@ class Model(object):
         nodes_path = os.path.join(shpdir, self.inp.name + '_nodes.shp')
         spatial.write_shapefile(nodes, nodes_path, geomtype='point', prj=prj)
 
+    @property
+    def summary(self):
+        if self._summary is None:
+            model_summary = functions.summarize_model(self)
+            self._summary = model_summary
+        return self._summary
 
 class SWMMIOFile(object):
     defaultSection = "Link Flow Summary"

--- a/swmmio/utils/functions.py
+++ b/swmmio/utils/functions.py
@@ -275,3 +275,25 @@ def find_network_trace(model, start_node, end_node,
         raise error.NoTraceFound
 
     return path_selection
+
+def summarize_model(model):
+    model_summary = dict()
+
+    # numbers of elements
+    model_summary['num_subcatchments'] = len(model.inp.subcatchments)
+    model_summary['num_conduits'] = len(model.inp.conduits)
+    model_summary['num_junctions'] = len(model.inp.junctions)
+    model_summary['num_outfalls'] = len(model.inp.outfalls)
+    model_summary['num_raingages'] = len(model.inp.raingages)
+
+    # calculated values - only calculate if elements exist
+    if len(model.inp.subcatchments) != 0:
+        model_summary['catchment_area'] = model.inp.subcatchments.Area.sum()
+        model_summary['mean_subcatchment_slope'] = ((model.inp.subcatchments.Area / model.inp.subcatchments.Area.sum()) * model.inp.subcatchments.PercSlope).sum()
+    
+    if len(model.inp.conduits) != 0:
+        model_summary['total_conduit_length'] = model.inp.conduits.Length.sum()
+    
+    if len(model.nodes.dataframe) != 0:
+        model_summary['invert_range'] = model.nodes().InvertElev.max() - model.nodes().InvertElev.min()
+    return model_summary


### PR DESCRIPTION
- Created ```summarize_model``` function and ```_summary``` model property. The ```summarize_model()``` function can very easily be expanded to include more fields. This could maybe be changed to a function in the future to add the option of a more detailed summary
- Created ```rpt_warnings``` function to read warnings from the head of the RPT file. The function requires a valid RPT file, but the run itself doesn't need to be successful. For warnings beyond those included in the RPT file, looks like ```drop_invalid_model_elements()``` currently provides some geometry warnings.