### PR TITLE
bump pillow version, drop Python 3.7 support, add 3.11 support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9, "3.10"]
+        python_version: [3.8, 3.9, "3.10", "3.11"]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Build dependencies
 pytest
-pillow>=6.2.0,<10.0.0
+Pillow==10.1.0
 numpy>=1.16.4
 pandas>=0.24.2
 pyshp==2.1.0

--- a/swmmio/graphics/drawing.py
+++ b/swmmio/graphics/drawing.py
@@ -217,8 +217,7 @@ def annotate_timestamp(draw):
     fnt = ImageFont.truetype(FONT_PATH, int(20 * scale))
 
     timestamp = strftime("%b-%d-%Y %H:%M:%S")
-    txt_height = draw.textsize(timestamp, fnt)[1]
-    txt_width = draw.textsize(timestamp, fnt)[0]
+    txt_width = draw.textlength(timestamp, fnt)
     xy = (size[0] - txt_width - 10, 15)
     draw.text(xy, timestamp, fill=grey, font=fnt)
 
@@ -228,7 +227,8 @@ def annotate_details(txt, draw):
     scale = 1 * size[0] / 2048
     fnt = ImageFont.truetype(FONT_PATH, int(20 * scale))
 
-    txt_height = draw.textsize(txt, fnt)[1]
+    _, top, _, bottom = draw.textbbox((0, 0), txt, fnt)
+    txt_height = top - bottom
 
     draw.text((10, size[1] - txt_height - 10),
               txt, fill=black, font=fnt)

--- a/swmmio/graphics/utils.py
+++ b/swmmio/graphics/utils.py
@@ -10,7 +10,7 @@ def save_image(img, img_path, antialias=True, auto_open=False):
     imgSize = (img.getbbox()[2], img.getbbox()[3])
     if antialias:
         size = (int(imgSize[0] * 0.5), int(imgSize[1] * 0.5))
-        img.thumbnail(size, Image.ANTIALIAS)
+        img.thumbnail(size, Image.LANCZOS)
 
     img.save(img_path)
     if auto_open:


### PR DESCRIPTION
This PR bumps the pillow version to resolve a [security issue](https://github.com/pyswmm/swmmio/security/dependabot/4), and updates references to its api were necessary. Because Pillow (and the Python Foundation) no longer supports Python 3.7, this PR also proposes to drop support for 3.7 and add test coverage for Python 3.11. 

Closes #212 

