### PR TITLE
Passing single label to .loc rather than list of labels. Change deprecated delim_whitespace=True to sep=r'\s+'

### DIFF
--- a/swmmio/graphics/profiler.py
+++ b/swmmio/graphics/profiler.py
@@ -32,7 +32,7 @@ def build_profile_plot(ax, model, path_selection):
         us_node, ds_node, link_id = link_set
         # Plot first Node
         if ind == 0:
-            invert_el = float(nodes.loc[[us_node]].InvertElev)
+            invert_el = float(nodes.loc[us_node].InvertElev)
             profile_config['nodes'].append({"id_name": us_node,
                                             "rolling_x_pos": rolling_x_pos,
                                             "invert_el": invert_el})
@@ -43,18 +43,18 @@ def build_profile_plot(ax, model, path_selection):
         # Add next link length to offset
         old_rolling_x_pos = rolling_x_pos
         # check link type
-        if links.loc[[link_id]].Type[0] == "CONDUIT":
-            rolling_x_pos += float(links.loc[[link_id]].Length)
-        elif links.loc[[link_id]].Type[0] == "WEIR":
+        if links.loc[link_id].Type == "CONDUIT":
+            rolling_x_pos += float(links.loc[link_id].Length)
+        elif links.loc[link_id].Type == "WEIR":
             rolling_x_pos += DEFAULT_WEIR_LENGTH
-        elif links.loc[[link_id]].Type[0] == "ORIFICE":
+        elif links.loc[link_id].Type == "ORIFICE":
             rolling_x_pos += DEFAULT_ORIFICE_LENGTH
-        elif links.loc[[link_id]].Type[0] == "PUMP":
+        elif links.loc[link_id].Type == "PUMP":
             rolling_x_pos += DEFAULT_PUMP_LENGTH
-        elif links.loc[[link_id]].Type[0] == "OUTLET":
+        elif links.loc[link_id].Type == "OUTLET":
             rolling_x_pos += DEFAULT_OUTLET_LENGTH
         # Plot DS node
-        invert_el = float(nodes.loc[[ds_node]].InvertElev)
+        invert_el = float(nodes.loc[ds_node].InvertElev)
         profile_config['nodes'].append({"id_name": ds_node,
                                         "rolling_x_pos": rolling_x_pos,
                                         "invert_el": invert_el})
@@ -87,17 +87,17 @@ def _add_node_plot(ax, x, model, node_name, link_set, surcharge_depth=0, width=M
     nodes = model.nodes.dataframe
     links = model.links.dataframe
 
-    invert_el = float(nodes.loc[[node_name]].InvertElev)
+    invert_el = float(nodes.loc[node_name].InvertElev)
     # Node Type checker
     if hasattr(model.inp, "junctions"):
         if node_name in model.inp.junctions.index:
-            depth = float(nodes.loc[[node_name]].MaxDepth)
+            depth = float(nodes.loc[node_name].MaxDepth)
     if hasattr(model.inp, "outfalls"):
         if node_name in model.inp.outfalls.index:
-            depth = float(links.loc[[link_id]].Geom1)
+            depth = float(links.loc[link_id].Geom1)
     if hasattr(model.inp, "storage"):
         if node_name in model.inp.storage.index:
-            depth = float(nodes.loc[[node_name]].MaxD)
+            depth = float(nodes.loc[node_name].MaxD)
 
     # Plotting Configuration
     ll_x, ll_y = x - width, invert_el
@@ -136,17 +136,17 @@ def _add_link_plot(ax, us_x_position, ds_x_position, model, link_set, width=0, g
     if model.inp.options.loc['LINK_OFFSETS','Value'] == "ELEVATION":
         us_node_el, ds_node_el = 0.0, 0.0
     else:
-        us_node_el = float(nodes.loc[[us_node]].InvertElev)
-        ds_node_el = float(nodes.loc[[ds_node]].InvertElev)
+        us_node_el = float(nodes.loc[us_node].InvertElev)
+        ds_node_el = float(nodes.loc[ds_node].InvertElev)
 
-    link_type = links.loc[[link_id]].Type[0]
+    link_type = links.loc[link_id].Type
     mid_x = []
     mid_y = []
     # check link type
     if link_type == "CONDUIT":
-        depth = float(links.loc[[link_id]].Geom1)
-        us_link_offset = float(links.loc[[link_id]].InOffset)
-        ds_link_offset = float(links.loc[[link_id]].OutOffset)
+        depth = float(links.loc[link_id].Geom1)
+        us_link_offset = float(links.loc[link_id].InOffset)
+        ds_link_offset = float(links.loc[link_id].OutOffset)
         #
         us_bot_x, us_bot_y = us_x_position + width, us_node_el + us_link_offset
         ds_bot_x, ds_bot_y = ds_x_position - width, ds_node_el + ds_link_offset
@@ -158,10 +158,10 @@ def _add_link_plot(ax, us_x_position, ds_x_position, model, link_set, width=0, g
                 lw=0.75, zorder=0)
 
     elif link_type == "ORIFICE":
-        depth = float(links.loc[[link_id]].Geom1)
-        us_link_offset = float(links.loc[[link_id]].CrestHeight)
-        ds_node_el = float(nodes.loc[[us_node]].InvertElev)  # Plot it flat
-        ds_link_offset = float(links.loc[[link_id]].CrestHeight)
+        depth = float(links.loc[link_id].Geom1)
+        us_link_offset = float(links.loc[link_id].CrestHeight)
+        ds_node_el = float(nodes.loc[us_node].InvertElev)  # Plot it flat
+        ds_link_offset = float(links.loc[link_id].CrestHeight)
 
         us_bot_x, us_bot_y = us_x_position + width, us_node_el + us_link_offset
         ds_bot_x, ds_bot_y = ds_x_position - width, ds_node_el + ds_link_offset
@@ -186,8 +186,8 @@ def _add_link_plot(ax, us_x_position, ds_x_position, model, link_set, width=0, g
                 lw=0.75, zorder=0)
 
     elif link_type == "WEIR":
-        depth = float(links.loc[[link_id]].Geom1)
-        us_link_offset = float(links.loc[[link_id]].CrestHeight)
+        depth = float(links.loc[link_id].Geom1)
+        us_link_offset = float(links.loc[link_id].CrestHeight)
         ds_link_offset = 0.0
 
         us_bot_x, us_bot_y = us_x_position + width, us_node_el + us_link_offset
@@ -274,17 +274,17 @@ def add_node_labels_plot(ax, model, profile_config, font_size=8,
     label_y_max = 0
     for val in profile_config['nodes']:
         name = val['id_name']
-        invert_el = float(nodes.loc[[name]].InvertElev)
+        invert_el = float(nodes.loc[name].InvertElev)
         # Node Type checker
         if hasattr(model.inp, "junctions"):
             if name in model.inp.junctions.index:
-                depth = float(nodes.loc[[name]].MaxDepth)
+                depth = float(nodes.loc[name].MaxDepth)
         if hasattr(model.inp, "outfalls"):
             if name in model.inp.outfalls.index:
                 depth = 0
         if hasattr(model.inp, "storage"):
             if name in model.inp.storage.index:
-                depth = float(nodes.loc[[name]].MaxD)
+                depth = float(nodes.loc[name].MaxD)
 
         calc = invert_el + depth
         if calc > label_y_max:
@@ -298,17 +298,17 @@ def add_node_labels_plot(ax, model, profile_config, font_size=8,
                 stagger_value = 4
         name = val['id_name']
         x_offset = val['rolling_x_pos']
-        invert_el = float(nodes.loc[[name]].InvertElev)
+        invert_el = float(nodes.loc[name].InvertElev)
         # Node Type checker
         if hasattr(model.inp, "junctions"):
             if name in model.inp.junctions.index:
-                depth = float(nodes.loc[[name]].MaxDepth)
+                depth = float(nodes.loc[name].MaxDepth)
         if hasattr(model.inp, "outfalls"):
             if name in model.inp.outfalls.index:
                 depth = 0
         if hasattr(model.inp, "storage"):
             if name in model.inp.storage.index:
-                depth = float(nodes.loc[[name]].MaxD)
+                depth = float(nodes.loc[name].MaxD)
         pos_y = invert_el + depth
         label = ax.annotate(name, xy=(x_offset, pos_y),
                             xytext=(x_offset, label_y_max + label_offset + stagger_value),

--- a/swmmio/tests/test_graphics.py
+++ b/swmmio/tests/test_graphics.py
@@ -83,7 +83,7 @@ def test_change_crs():
     J4-001.1 -70.959423  43.730452
     J2-095.1 -70.951378  43.767796
     """
-    v2_test = pd.read_csv(StringIO(s), index_col=0, delim_whitespace=True, skiprows=[0])
+    v2_test = pd.read_csv(StringIO(s), index_col=0, sep=r'\s+', skiprows=[0])
     assert v2['X'].values == pytest.approx(v2_test['X'].values, rel=1e-3)
     assert v2['Y'].values == pytest.approx(v2_test['Y'].values, rel=1e-3)
 

--- a/swmmio/utils/dataframes.py
+++ b/swmmio/utils/dataframes.py
@@ -104,7 +104,7 @@ def dataframe_from_rpt(rpt_path, section, element_id=None):
 
     # extract the string and read into a dataframe
     s = extract_section_of_file(rpt_path, start_strings, end_strings)
-    df = pd.read_csv(StringIO(s), header=None, sep='\s+', skiprows=[0],
+    df = pd.read_csv(StringIO(s), header=None, sep=r'\s+', skiprows=[0],
                      index_col=0, names=cols)
 
     # confirm index name is string
@@ -164,7 +164,7 @@ def dataframe_from_inp(inp_path, section, additional_cols=None, quote_replace=' 
         return pd.read_csv(StringIO(s), delim_whitespace=False)
     else:
         try:
-            df = pd.read_csv(StringIO(s), header=None, sep='\s+',
+            df = pd.read_csv(StringIO(s), header=None, sep=r'\s+',
                              skiprows=[0], index_col=0, names=cols)
         except:
             raise IndexError(f'failed to parse {section} with cols: {cols}. head:\n{s[:500]}')
@@ -225,7 +225,7 @@ def get_inp_options_df(inp_path):
     ops_tag = '[OPTIONS]'
     ops_cols = INP_OBJECTS['OPTIONS']['columns']
     ops_string = extract_section_of_file(inp_path, ops_tag, INP_SECTION_TAGS, comment=';')
-    ops_df = pd.read_csv(StringIO(ops_string), header=None, delim_whitespace=True, skiprows=[0],
+    ops_df = pd.read_csv(StringIO(ops_string), header=None, sep=r'\s+', skiprows=[0],
                          index_col=0, names=ops_cols)
     return ops_df
 


### PR DESCRIPTION
Passing single label to .loc rather than list of labels to return series rather than dataframe. This avoids FutureWarning: calling float on single element series and FutureWarning: Series.__getitem__ treating keys as positions is deprecated. 

Changed deprecated `delim_whitespace=True` to `sep=r'\s+'`. 

Changed `'\s+'` to `r'\s+'` to remove invalid escape sequence '\s' warning.
