### PR TITLE
handle all future warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    uses_geopandas: marks tests that use Geopandas (deselect with '-m "not uses_geopandas"')
+    serial

--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -1542,7 +1542,7 @@ class inp(SWMMIOFile):
                 pattern_entry['Type'] = pattern['Type'].iloc[0]
                 if pattern.shape[0] > 1:
                     # shift pattern values to the right
-                    pattern.iloc[1::, 1::] = pattern.iloc[1::, 0:-1].values
+                    pattern.iloc[1::, 1::] = pattern.iloc[1::, 0:-1].values.astype(float)
                     pattern['Factors'] = pattern['Factors'].astype(float)
                 values = pattern.iloc[:, 1:].values.flatten()
                 for i in range(len(values)):

--- a/swmmio/tests/test_dataframes.py
+++ b/swmmio/tests/test_dataframes.py
@@ -207,7 +207,7 @@ def test_links_dataframe_from_rpt(test_model_02):
     C2        PUMP  4.33       0  09:59  0.22       NaN       NaN
     C3        WEIR  7.00       0  10:00  0.33       NaN       NaN
     '''
-    lfs_df = pd.read_csv(StringIO(s), index_col=0, delim_whitespace=True, skiprows=[0])
+    lfs_df = pd.read_csv(StringIO(s), index_col=0, sep=r'\s+', skiprows=[0])
     assert(lfs_df.equals(link_flow_summary))
 
 
@@ -257,7 +257,7 @@ def test_polygons(test_model_02):
     S4   -154.695 -168.608
     S4   -148.499 -126.120
     """
-    poly1 = pd.read_csv(StringIO(s), index_col=0, delim_whitespace=True, skiprows=[0])
+    poly1 = pd.read_csv(StringIO(s), index_col=0, sep=r'\s+', skiprows=[0])
 
     assert poly1.equals(test_model_02.inp.polygons)
 

--- a/swmmio/utils/dataframes.py
+++ b/swmmio/utils/dataframes.py
@@ -161,7 +161,7 @@ def dataframe_from_inp(inp_path, section, additional_cols=None, quote_replace=' 
     
     if headers[sect]['columns'][0] == 'blob':
         # return the whole row, without specific col headers
-        return pd.read_csv(StringIO(s), delim_whitespace=False)
+        return pd.read_csv(StringIO(s))
     else:
         try:
             df = pd.read_csv(StringIO(s), header=None, sep=r'\s+',

--- a/swmmio/version_control/utils.py
+++ b/swmmio/version_control/utils.py
@@ -74,7 +74,7 @@ def write_inp_section(file_object, allheaders, sectionheader, section_data, pad_
             numformatter = {hedr: '  {{:<{}}}'.format(section_data[hedr].apply(str).str.len().max()).format
                             for hedr in section_data.columns if section_data[hedr].dtype != "O"}
             objectformatter.update(numformatter)
-            add_str = section_data.fillna(na_fill).to_string(
+            add_str = section_data.infer_objects(copy=False).fillna(na_fill).to_string(
                 index_names=False,
                 header=True,
                 justify='left',


### PR DESCRIPTION
Minor refactoring to address all of the current FutureWarnings and PytestUnknownMarkWarning raised by the tests. This wrangles a few references to `delim_whitespace` that slipped through the cracks in addition to many instances of the follow warnings:

- `FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.` 
- `FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version.`
- `FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas.`
- `PytestUnknownMarkWarning: Unknown pytest.mark.uses_geopandas`

After these changes, warnings raised when running tests should reduce from 107 to 15. 


> [!NOTE]
> The remaining 15 warnings are raised by `swmmio` itself, in situations where the  `dataframe_from_inp` function attempts to extract a section of the INP that is not found. For example:  
> ```
> UserWarning: ORIFICES section not found in /swmmio/swmmio/tests/data/model_full_features_network_xy.inp
> ```
> I'm tired of seeing these warnings too. But in some cases these may be important. Maybe we can provide a user config that optionally silences these? I'm open to ideas. But we can tackle that separately