### PR TITLE
Fix GitHub actions config for uploading docs 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
         run: sphinx-build docs docs/build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload build
           path: './docs/build'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
         run: sphinx-build docs docs/build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           # Upload build
           path: './docs/build'


### PR DESCRIPTION
Necessary to use the updated upload-artifact GitHub action, per https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md