### PR TITLE
Bug fix for nodes with exclusively numerical names

### DIFF
--- a/swmmio/tests/data/__init__.py
+++ b/swmmio/tests/data/__init__.py
@@ -33,6 +33,7 @@ MODEL_INFILTRAION_PARSE_FAILURE = os.path.join(DATA_PATH, 'model-with-infiltrati
 MODEL_EXTCNTRLMODEL = os.path.join(DATA_PATH, 'SWMMExtCntrlModel.inp')
 MODEL_TEST_INLET_DRAINS = os.path.join(DATA_PATH, 'test_inlet_drains.inp')
 MODEL_GROUNDWATER = os.path.join(DATA_PATH, 'groundwater_model.inp')
+MODEL_NODES_INTEGER_NAMES = os.path.join(DATA_PATH, 'nodes_integer_names.inp')
 
 # test rpt paths
 RPT_FULL_FEATURES = os.path.join(DATA_PATH, 'model_full_features_network.rpt')

--- a/swmmio/tests/data/nodes_integer_names.inp
+++ b/swmmio/tests/data/nodes_integer_names.inp
@@ -1,0 +1,95 @@
+[TITLE]
+;;Project Title/Notes
+
+[OPTIONS]
+;;Option             Value
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         DYNWAVE
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+ALLOW_PONDING        NO
+SKIP_STEADY_STATE    NO
+
+START_DATE           03/03/2025
+START_TIME           00:00:00
+REPORT_START_DATE    03/03/2025
+REPORT_START_TIME    00:00:00
+END_DATE             03/03/2025
+END_TIME             06:00:00
+SWEEP_START          1/1
+SWEEP_END            12/31
+DRY_DAYS             0
+REPORT_STEP          00:15:00
+WET_STEP             00:05:00
+DRY_STEP             01:00:00
+ROUTING_STEP         0:00:20 
+RULE_STEP            00:00:00
+
+INERTIAL_DAMPING     PARTIAL
+NORMAL_FLOW_LIMITED  BOTH
+FORCE_MAIN_EQUATION  H-W
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         0
+MAX_TRIALS           0
+HEAD_TOLERANCE       0
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Data Source    Parameters
+;;-------------- ----------------
+CONSTANT         0.0
+DRY_ONLY         NO
+
+[JUNCTIONS]
+;;Name           Elevation  MaxDepth   InitDepth  SurDepth   Aponded   
+;;-------------- ---------- ---------- ---------- ---------- ----------
+1                0          0          0          0          0         
+2                0          0          0          0          0         
+
+[OUTFALLS]
+;;Name           Elevation  Type       Stage Data       Gated    Route To        
+;;-------------- ---------- ---------- ---------------- -------- ----------------
+3                0          FREE                        NO                       
+
+[CONDUITS]
+;;Name           From Node        To Node          Length     Roughness  InOffset   OutOffset  InitFlow   MaxFlow   
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+1                1                2                400        0.01       0          0          0          0         
+2                2                3                400        0.01       0          0          0          0         
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels    Culvert   
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ---------- ----------
+1                CIRCULAR     1                0          0          0          1                    
+2                CIRCULAR     1                0          0          0          1                    
+
+[REPORT]
+;;Reporting Options
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS 0.000 0.000 10000.000 10000.000
+Units      None
+
+[COORDINATES]
+;;Node           X-Coord            Y-Coord           
+;;-------------- ------------------ ------------------
+1                2399.691           6496.914          
+2                5162.037           6033.951          
+3                3495.370           4706.790          
+
+[VERTICES]
+;;Link           X-Coord            Y-Coord           
+;;-------------- ------------------ ------------------
+1                4297.840           7206.790          
+
+[Polygons]

--- a/swmmio/tests/test_dataframes.py
+++ b/swmmio/tests/test_dataframes.py
@@ -7,7 +7,8 @@ from swmmio.tests.data import (MODEL_FULL_FEATURES_PATH, MODEL_FULL_FEATURES__NE
                                MODEL_FULL_FEATURES_XY, DATA_PATH, MODEL_XSECTION_ALT_03,
                                MODEL_CURVE_NUMBER, MODEL_MOD_HORTON, MODEL_GREEN_AMPT, MODEL_MOD_GREEN_AMPT,
                                MODEL_INFILTRAION_PARSE_FAILURE, OWA_RPT_EXAMPLE,
-                               MODEL_TEST_INLET_DRAINS, MODEL_PUMP_CONTROL)
+                               MODEL_TEST_INLET_DRAINS, MODEL_PUMP_CONTROL,
+                               MODEL_NODES_INTEGER_NAMES)
 from swmmio.utils.dataframes import (dataframe_from_rpt, dataframe_from_inp, dataframe_from_bi)
 from swmmio.utils.text import get_inp_sections_details
 from swmmio.run_models.run import run_simple
@@ -85,6 +86,12 @@ def test_conduits_dataframe(test_model_01):
     conduits = m.conduits()
     assert (list(conduits.index) == ['C1:C2'])
 
+    #Inlet/Outlet node ID not transformed to real when they are exclusively integers
+    m = swmmio.Model(MODEL_NODES_INTEGER_NAMES)
+    conduits = m.conduits()
+    assert(conduits.loc["1"].InletNode == "1")
+    assert(conduits.loc["1"].OutletNode == "2")
+
 
 @pytest.mark.uses_geopandas
 def test_pumps_composite(test_model_01):
@@ -123,6 +130,11 @@ def test_nodes_dataframe():
     assert (nodes.loc['dummy_node3', 'coords'] == [(-4205.457, 9695.024)])
     assert (nodes.loc['dummy_node4', 'MaxDepth'] == 12.59314)
     assert (nodes.loc['dummy_node5', 'PondedArea'] == 73511)
+
+    #ID not changed to real when names are exclusively integers
+    m = swmmio.Model(MODEL_NODES_INTEGER_NAMES)
+    nodes = m.nodes()
+    assert (list(nodes.index) == ["1", "2", "3"])
 
 
 def test_infiltration_section():

--- a/swmmio/utils/dataframes.py
+++ b/swmmio/utils/dataframes.py
@@ -158,21 +158,28 @@ def dataframe_from_inp(inp_path, section, additional_cols=None, quote_replace=' 
     if n_tokens > len(cols):
         cols = cols + ["col"+str(len(cols)+i) for i in range(n_tokens-len(cols))]
     cols = cols + additional_cols
-    
+
+    input_types = get_pandas_input_dtype(section = section)
+    input_types = {k:v for k,v in input_types.items() if k in range(len(cols))}
+
     if headers[sect]['columns'][0] == 'blob':
         # return the whole row, without specific col headers
         return pd.read_csv(StringIO(s))
     else:
         try:
             df = pd.read_csv(StringIO(s), header=None, sep=r'\s+',
-                             skiprows=[0], index_col=0, names=cols)
+                             skiprows=[0], index_col=0, names=cols, dtype = input_types)
         except:
             raise IndexError(f'failed to parse {section} with cols: {cols}. head:\n{s[:500]}')
-
+    
     # confirm index name is string
     df = df.rename(index=str)
     return df
 
+def get_pandas_input_dtype(section : str) -> dict[int, ]:
+    """Column dtypes for each section so that pandas doesn't guess them."""
+    if section == "CONDUITS": return {0:str, 1:str, 2:str} #prevent numerical node IDS from turning into floats
+    return {}
 
 def get_link_coords(row, nodexys, verticies):
     """for use in an df.apply, to get coordinates of a conduit/link """


### PR DESCRIPTION
Nodes with numerical names were being read in the InletNode and OutletNode parameters of the CONDUITS section as floats, for instance 1.0 instead of "1".