### PR TITLE
dont exclude tests from build, fix windows path refs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,9 +43,9 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         # uv run flake8 swmmio --exclude=swmmio/vendor --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      run: |
-        uv run pytest -m "not uses_geopandas"
-        uv run python -m doctest swmmio/core.py 
+      run: uv run pytest -v -m "not uses_geopandas"
+    - name: Test doctests
+      run: uv run python -m doctest swmmio/core.py
 
   release:
     name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,7 @@ include = [
     "swmmio/tests/data/*.txt",
 ]
 exclude = [
-    "tests",
-    "tests.*",
+
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,10 @@ testpaths = ["swmmio/tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+markers = [
+    "uses_geopandas: marks tests that use Geopandas (deselect with '-m \"not uses_geopandas\"')",
+    "serial",
+]
 filterwarnings = [
     "ignore:.*section not found in.*:UserWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ testpaths = ["swmmio/tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+filterwarnings = [
+    "ignore:.*section not found in.*:UserWarning",
+]
 
 [dependency-groups]
 dev = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    uses_geopandas: marks tests that use Geopandas (deselect with '-m "not uses_geopandas"')
-    serial

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ packaging==26.2
     # via pyswmm
 pandas==2.3.3
     # via swmmio (pyproject.toml)
-pillow==10.2.0
+pillow==12.2.0
     # via swmmio (pyproject.toml)
 pyproj==3.7.2
     # via swmmio (pyproject.toml)

--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -6,13 +6,10 @@ import os
 import glob
 
 import pandas as pd
-import numpy as np
 
-from swmmio.utils import spatial
-from swmmio.utils import functions
+from swmmio.utils import spatial, functions
 from swmmio.utils.dataframes import dataframe_from_rpt, get_link_coords, \
     create_dataframe_multi_index, get_inp_options_df, dataframe_from_inp
-from swmmio.tests.data import MODEL_FULL_FEATURES__NET_PATH, MODEL_FULL_FEATURES_XY
 import swmmio
 from swmmio.elements import ModelSection, Links, Nodes
 from swmmio.defs import INP_OBJECTS, INFILTRATION_COLS, RPT_OBJECTS, COMPOSITE_OBJECTS

--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -420,6 +420,7 @@ class Model(object):
 
         Examples
         --------
+        >>> from swmmio.tests.data import MODEL_FULL_FEATURES_XY
         >>> m = swmmio.Model(MODEL_FULL_FEATURES_XY, crs="EPSG:2272")
         >>> m.to_crs("EPSG:4326") # convert to WGS84 web mercator
         >>> m.inp.coordinates.round(5)  #doctest: +NORMALIZE_WHITESPACE

--- a/swmmio/defs/config.py
+++ b/swmmio/defs/config.py
@@ -1,10 +1,11 @@
 import os
+import sys
 
 # This is the swmmio project root
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # path to the Python executable used to run your version of Python
-PYTHON_EXE_PATH = "python"#os.path.join(os.__file__.split("lib/")[0],"bin","python")
+PYTHON_EXE_PATH = sys.executable
 
 # feature class name of parcels in geodatabase
 PARCEL_FEATURES = r'PWD_PARCELS_SHEDS_PPORT'

--- a/swmmio/tests/test_functions.py
+++ b/swmmio/tests/test_functions.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import unittest
 from unittest.mock import patch, mock_open, MagicMock
@@ -117,7 +119,7 @@ class TestCheckIfUrlAndDownload(unittest.TestCase):
         mock_gettempdir.return_value = '/tmp'
 
         url = 'https://example.com/path/to/file.txt'
-        expected_path = '/tmp/file.txt'
+        expected_path = os.path.join('/tmp', 'file.txt')
 
         result = check_if_url_and_download(url)
 

--- a/swmmio/tests/test_graphics.py
+++ b/swmmio/tests/test_graphics.py
@@ -2,11 +2,14 @@ import os
 import tempfile
 from io import StringIO
 
+import matplotlib
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
 from collections.abc import Mapping
 from _pytest.python_api import ApproxMapping
+import pyswmm
 
 from swmmio.tests.data import (DATA_PATH, MODEL_FULL_FEATURES_XY,
                                MODEL_FULL_FEATURES__NET_PATH, MODEL_A_PATH,
@@ -17,7 +20,9 @@ from swmmio.graphics import swmm_graphics as sg
 from swmmio.utils.spatial import centroid_and_bbox_from_coords, change_crs
 from swmmio import (find_network_trace, build_profile_plot,
                     add_hgl_plot, add_node_labels_plot, add_link_labels_plot)
-import pyswmm
+
+# Use non-interactive backend for headless environments e.g. Windows steps in GitHub Actions.
+matplotlib.use('Agg')  
 
 
 def test_draw_model():

--- a/swmmio/wrapper/pyswmm_wrapper.py
+++ b/swmmio/wrapper/pyswmm_wrapper.py
@@ -62,5 +62,5 @@ def run_model():
 
     return 0
 
-if __name__ in "__main__":
+if __name__ == "__main__":
     run_model()


### PR DESCRIPTION
This fixes an issue where the pychrs.tests module was not included in the build. This was a problem because we reference the test module in some examples. 

While making this fix, I also noticed that tests were actually failing in Windows even though GitHub Actions wasn't flagging them as failures in Windows because previously we did the tests and doctests in the same command. now they run in distinct steps, so windows failures will be raised in the future. 

I fixed the issues in windows by making a few path references OS-dynamic and configured matplotlib properly for headless environments in test_graphics. 